### PR TITLE
Fix to TaskP_Object size to support BSD and NETX Driver integration improvements

### DIFF
--- a/source/kernel/dpl/TaskP.h
+++ b/source/kernel/dpl/TaskP.h
@@ -85,7 +85,7 @@ typedef struct {
 /**
  * \brief Max size of task object across all OS's
  */
-#define TaskP_OBJECT_SIZE_MAX       (200U)
+#define TaskP_OBJECT_SIZE_MAX       (208U)
 /**
  * \brief Opaque task object used with the task APIs
  */

--- a/source/networking/netxduo/netxduo_enet/netxduo_enet.c
+++ b/source/networking/netxduo/netxduo_enet/netxduo_enet.c
@@ -684,8 +684,13 @@ static void nx_enet_drv_notifyRxPackets(void *cbArg)
     for (size_t if_ix = 0u; if_ix < NX_DRIVER_MAX_INTERFACE_COUNT; if_ix++) {
         for (size_t ch_ix = 0u; ch_ix < g_nx_enet_drv_data.t_if_data[if_ix].rx_ch_cnt; ch_ix++) {
             if (g_nx_enet_drv_data.t_if_data[if_ix].t_rx_ch[ch_ix] == p_rx_ch) {
-                /* Signal to NETX that there are received packets to process. */
-                _nx_ip_driver_deferred_processing(g_nx_enet_drv_data.t_if_data[if_ix].netx_ip_ptr);
+
+                /* Make sure the ip was created, otherwise drop the packet. */
+                if (g_nx_enet_drv_data.t_if_data[if_ix].netx_ip_ptr != NULL) {
+
+                    /* Signal to NETX that there are received packets to process. */
+                    _nx_ip_driver_deferred_processing(g_nx_enet_drv_data.t_if_data[if_ix].netx_ip_ptr);
+                }
             }
         }
     }
@@ -701,6 +706,10 @@ static void nx_enet_drv_notifyTxPackets(void *cbArg)
     for (size_t if_ix = 0u; if_ix < NX_DRIVER_MAX_INTERFACE_COUNT; if_ix++) {
         for (size_t ch_ix = 0u; ch_ix < g_nx_enet_drv_data.t_if_data[if_ix].tx_ch_cnt; ch_ix++) {
             if (g_nx_enet_drv_data.t_if_data[if_ix].t_tx_ch[ch_ix] == p_tx_ch) {
+
+                /* Should not be transmitting before the ip was created. */
+                DebugP_assert(g_nx_enet_drv_data.t_if_data[if_ix].netx_ip_ptr != NULL);
+
                 _nx_ip_driver_deferred_processing(g_nx_enet_drv_data.t_if_data[if_ix].netx_ip_ptr);
             }
         }


### PR DESCRIPTION
This pull request fix two issues found during testing. The first is that the BSD module addon from NETX added in a previous pull request requires an increase to the size of the TaskP_Object which is increased to 208 bytes in this pull request.

The second issue is a check added to the ENET driver integration for NETX to make sure that packets are not forwarded to NETX before it is fully initialized. This is required since the ENET module is created and initialized before NETX by the SDK.