### PR TITLE
AM62AX ThreadX Doxygen Tagging

### DIFF
--- a/docs_src/docs/api_guide/components/fs/filex.md
+++ b/docs_src/docs/api_guide/components/fs/filex.md
@@ -1,3 +1,4 @@
+\cond THREADX
 # FileX {#FS_FILEX}
 
 [TOC]
@@ -28,3 +29,4 @@ For the full FileX documentation, please refer to the below table.
     <td>Complete documentation of the FileX file system and API references
 </tr>
 </table>
+\endcond

--- a/docs_src/docs/api_guide/components/fs/fs.md
+++ b/docs_src/docs/api_guide/components/fs/fs.md
@@ -11,6 +11,6 @@ It consists of below sub-modules
 \cond SOC_AM64X || SOC_AM243X || SOC_AM62AX || SOC_AM62X || SOC_AM62DX
 - \subpage FS_FREERTOS_FAT
 \endcond
-\cond SOC_AM62AX
+\cond SOC_AM62AX && THREADX
 - \subpage FS_FILEX
 \endcond

--- a/docs_src/docs/api_guide/components/kernel/os/os.md
+++ b/docs_src/docs/api_guide/components/kernel/os/os.md
@@ -11,7 +11,7 @@ It consists of below sub-modules
 \cond SOC_AWR294X
 - \subpage KERNEL_SAFERTOS_PAGE
 \endcond
-\cond SOC_AM62AX
+\cond SOC_AM62AX && THREADX
 - \subpage KERNEL_THREADX
 \endcond
 

--- a/docs_src/docs/api_guide/components/kernel/os/threadx.md
+++ b/docs_src/docs/api_guide/components/kernel/os/threadx.md
@@ -1,3 +1,4 @@
+\cond THREADX
 # ThreadX {#KERNEL_THREADX}
 
 [TOC]
@@ -27,3 +28,4 @@ For the full ThreadX API reference, please refer to the below table.
     <td>Complete documentation of the ThreadX kernel and API references
 </tr>
 </table>
+\endcond

--- a/docs_src/docs/api_guide/components/networking/networking.md
+++ b/docs_src/docs/api_guide/components/networking/networking.md
@@ -117,7 +117,7 @@ Ethernet Low-Level Driver (\ref ENET_LLD) is a driver that aims at providing an 
 
 ### TCP/IP Stack
 
-\cond SOC_AM62AX
+\cond SOC_AM62AX && THREADX
 - \subpage NETWORKING_NETXDUO
 \endcond
 

--- a/docs_src/docs/api_guide/components/networking/networking_netxduo.md
+++ b/docs_src/docs/api_guide/components/networking/networking_netxduo.md
@@ -1,3 +1,4 @@
+\cond THREADX
 # NetxDuo {#NETWORKING_NETXDUO}
 
 [TOC]
@@ -28,3 +29,4 @@ For the full NetxDuo documentation, please refer to the below table.
     <td>Complete documentation of the NetxDuo TCP/IP network stack and API references
 </tr>
 </table>
+\endcond

--- a/docs_src/docs/api_guide/device/am62ax/includes.cfg
+++ b/docs_src/docs/api_guide/device/am62ax/includes.cfg
@@ -65,6 +65,7 @@ INPUT+= $(MCU_PLUS_SDK_PATH)/docs_src/docs/api_guide/components/networking/netwo
 @INCLUDE = $(MCU_PLUS_SDK_PATH)/docs_src/docs/api_guide/components/tools/tools_sysfw.cfg
 # Used to selectively pick DEVICE specific sections within .md files
 ENABLED_SECTIONS = SOC_AM62AX
+ENABLED_SECTIONS += THREADX
 
 # SOC specific aliases
 ALIASES+=VAR_SOC_NAME="AM62AX"

--- a/docs_src/docs/api_guide/examples/examples.md
+++ b/docs_src/docs/api_guide/examples/examples.md
@@ -49,7 +49,9 @@ This page lists all the examples and demos supported in this SDK.
 -# \subpage EXAMPLES_DRIVERS_SBL
 -# \subpage EXAMPLES_DRIVERS_RESET_ISOLATION
 -# \subpage EXAMPLES_DRIVERS_BIST_RESULT
+\cond THREADX
 -# \subpage EXAMPLES_FS
+\endcond
 -# \subpage EXAMPLES_NETWORKING
 -# \subpage EXAMPLES_OTP
 -# \subpage EXAMPLES_SDL

--- a/docs_src/docs/api_guide/examples/examples_fs.md
+++ b/docs_src/docs/api_guide/examples/examples_fs.md
@@ -1,3 +1,4 @@
+\cond THREADX
 #  File Systems {#EXAMPLES_FS}
 
 This page lists all the examples related to usage of file systems.
@@ -5,4 +6,5 @@ This page lists all the examples related to usage of file systems.
 
 \cond SOC_AM62AX
 -# \subpage EXAMPLES_FS_FILEX_HELLO_WORLD
+\endcond
 \endcond

--- a/docs_src/docs/api_guide/examples/examples_kernel.md
+++ b/docs_src/docs/api_guide/examples/examples_kernel.md
@@ -32,8 +32,10 @@ including driver porting layer examples.
 -# \subpage EXAMPLES_KERNEL_FREERTOS_MEMCPY_BENCHMARK
 \endcond
 \cond SOC_AM62AX
+\cond THREADX
 -# \subpage EXAMPLES_KERNEL_THREADX_HELLO_WORLD
 -# \subpage EXAMPLES_KERNEL_THREADX_TASK_SWITCH
+\endcond
 \endcond
 \cond SOC_AM62AX || SOC_AM62DX
 -# \subpage EXAMPLES_KERNEL_DPL_DEMO

--- a/docs_src/docs/api_guide/examples/examples_networking.md
+++ b/docs_src/docs/api_guide/examples/examples_networking.md
@@ -16,12 +16,14 @@ This page lists all the examples related to Ethernet Communication.
 \endcond
 
 \cond SOC_AM62AX
+\cond THREADX
 ### TCP/IP Examples using NetxDuo Stack on ThreadX
 -# \subpage EXAMPLES_ENET_NETXDUO_CPSW_MAC
 -# \subpage EXAMPLES_ENET_NETXDUO_CPSW_SWITCH
 -# \subpage EXAMPLES_ENET_NETXDUO_CPSW_TCPCLIENT
 -# \subpage EXAMPLES_ENET_NETXDUO_CPSW_TCPSERVER
 -# \subpage EXAMPLES_ENET_NETXDUO_CPSW_UDPCLIENT
+\endcond
 \endcond
 
 \cond SOC_AM62X


### PR DESCRIPTION
Added conditional inclusion of the ThreadX documentation. Note that due to Doxygen limitations this leaves empty pages in the doxygen treeview when the ThreadX documentation is disabled.

(Note that this pull request should be merged after the "Threadx Support for Drivers Examples and Test for AM62AX " pull request.)
